### PR TITLE
Waggleworx/pre publish adjustments

### DIFF
--- a/linkwarden/values.yaml
+++ b/linkwarden/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/linkwarden/linkwarden
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   tag: "latest"
 
 postgres:

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ This Helm chart deploys the Linkwarden application on a Kubernetes cluster.
 1. **Add the Helm repository:**
 
     ```sh
-    helm repo add linkwarden https://soubenz.github.io/linkwarden-helm-chart/
+    helm repo add linkwarden https://waggleworx.github.io/linkwarden-helm-chart/
     helm repo update
     ```
 
@@ -37,7 +37,7 @@ The following table lists the configurable parameters of the Linkwarden chart an
 |-------------------------------------------|-----------------------------------------------------------------------------|----------------------------------------------|
 | `replicaCount`                            | Number of replicas                                                          | `1`                                           |
 | `image.repository`                        | Image repository                                                            | `ghcr.io/linkwarden/linkwarden`              |
-| `image.pullPolicy`                        | Image pull policy                                                           | `IfNotPresent`                               |
+| `image.pullPolicy`                        | Image pull policy                                                           | `Always`                                     |
 | `image.tag`                               | Image tag                                                                   | `latest`                                     |
 | `postgres.enabled`                        | Enable PostgreSQL                                                           | `true`                                       |
 | `postgres.host`                           | PostgreSQL host                                                             | `postgres`                                   |


### PR DESCRIPTION
These are updates to point at my username's helm chart once it's published, and shift to a pullPolicy that actually pulls new versions.  Previously, if version 1.5.0 is pulled as "latest" it would not re-pull when v2.0.0 is released because 1.5.0 is still labeled "latest"